### PR TITLE
feat: カテゴリーCRUD実装 #4

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\CategoryRequest;
+use App\Models\Category;
+
+class CategoryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $categories = Category::withCount('tasks')->orderBy('created_at', 'desc')->get();
+        return view('categories.index', compact('categories'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('categories.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(CategoryRequest $request)
+    {
+        Category::create($request->validated());
+        return redirect()->route('categories.index')->with('success', 'カテゴリーを作成しました。');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Category $category)
+    {
+        $category->load('tasks');
+        return view('categories.show', compact('category'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Category $category)
+    {
+        return view('categories.edit', compact('category'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(CategoryRequest $request, Category $category)
+    {
+        $category->update($request->validated());
+        return redirect()->route('categories.index')->with('success', 'カテゴリーを更新しました。');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Category $category)
+    {
+        // カテゴリーに紐づくタスクがある場合は削除不可
+        if ($category->tasks()->count() > 0) {
+            return redirect()->route('categories.index')->with('error', 'タスクが紐づいているカテゴリーは削除できません。');
+        }
+        $category->delete();
+        return redirect()->route('categories.index')->with('success', 'カテゴリーを削除しました。');
+    }
+}

--- a/app/Http/Requests/CategoryRequest.php
+++ b/app/Http/Requests/CategoryRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+            'required',
+            'string',
+            'max:255',
+            Rule::unique('categories', 'name')->ignore($this->category),
+            ],
+        ];
+    }
+
+        /**
+     * バリデーションメッセージ
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'カテゴリー名は必須です。',
+            'name.max' => 'カテゴリー名は255文字以内で入力してください。',
+            'name.unique' => 'このカテゴリー名は既に使用されています。',
+        ];
+    }
+
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CategoryController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -18,7 +19,16 @@ Route::get('/', function () {
 });
 
 // 仮ルート（Chapter 6で本実装に置き換え）
+// Route::middleware('auth')->group(function () {
+//     Route::get('/tasks', fn() => 'タスク一覧（準備中）')->name('tasks.index');
+//     Route::get('/categories', fn() => 'カテゴリー一覧（準備中）')->name('categories.index');
+// });
+
+// 認証が必要なルート
 Route::middleware('auth')->group(function () {
+    // カテゴリーのCRUDルート（仮ルートから置き換え）
+    Route::resource('categories', CategoryController::class);
+
+    // タスクの仮ルート（次のセクションで本実装に置き換え）
     Route::get('/tasks', fn() => 'タスク一覧（準備中）')->name('tasks.index');
-    Route::get('/categories', fn() => 'カテゴリー一覧（準備中）')->name('categories.index');
 });


### PR DESCRIPTION
## 概要
カテゴリーのCRUD機能を実装しました。

## 変更内容
- CategoryControllerの作成
- カテゴリー用ビューの作成（index, create, show, edit）
- ルーティングの設定

## 動作確認
- [ ] カテゴリー一覧が表示される
- [ ] カテゴリーの作成ができる
- [ ] カテゴリーの編集ができる
- [ ] カテゴリーの削除ができる

## 対応Issue
close #4