### PR TITLE
feat: 公開API実装

### DIFF
--- a/app/Http/Controllers/Api/TaskController.php
+++ b/app/Http/Controllers/Api/TaskController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Http\Resources\TaskResource;
+use App\Models\Task;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class TaskController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $tasks = Task::with(['category', 'user'])
+            ->orderBy('priority', 'desc')
+            ->orderBy('created_at', 'desc')
+            ->get();
+        return TaskResource::collection($tasks);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Task $task): TaskResource
+    {
+        $task->load(['category', 'user']);
+        return new TaskResource($task);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Resources/TaskResource.php
+++ b/app/Http/Resources/TaskResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->titile,
+            'description' => $this->description,
+            'priority' => $this->priority,
+            'priority_label' => $this->priority_label,
+            'category' => [
+                'id' => $this->category->id,
+                'name' => $this->category->name,
+            ],
+            'user' => [
+                'id' => $this->user->id,
+                'name' => $this->user->name,
+            ],
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\TaskController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -17,3 +18,6 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+// 公開API（認証不要）
+Route::apiResource('tasks', TaskController::class)->only(['index', 'show']);


### PR DESCRIPTION
## 概要
タスク情報を取得する公開APIを実装しました。

## 変更内容
- Api\TaskControllerの作成
- TaskResourceの作成
- APIルーティングの設定

## エンドポイント
- GET /api/tasks - タスク一覧取得
- GET /api/tasks/{id} - タスク詳細取得

## 動作確認
- [ ] タスク一覧がJSON形式で返る
- [ ] タスク詳細がJSON形式で返る

## 対応Issue
close #7