### PR TITLE
feat: 認証機能のテスト実装

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,7 +59,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                // PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Pdo\Mysql::ATTR_SSL_CA ,
             ]) : [],
         ],
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\TaskController;
 use Illuminate\Support\Facades\Route;
 
 /*

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function ログイン画面を表示できる(): void
+    {
+        // Act
+        $response = $this->get(route('login'));
+
+        // Assert
+        $response->assertStatus(200);
+    }
+
+    /** @test */
+    public function 正しい認証情報でログインできる(): void
+    {
+        // Arrange
+        $user = User::factory()->create([
+            'password' => bcrypt('password123'),
+        ]);
+
+        // Act
+        $response = $this->post(route('login'), [
+            'email' => $user->email,
+            'password' => 'password123',
+        ]);
+
+        // Assert
+        $response->assertRedirect(route('tasks.index'));
+        $this->assertAuthenticatedAs($user);
+    }
+
+    /** @test */
+    public function 間違ったパスワードではログインできない(): void
+    {
+        // Arrange
+        $user = User::factory()->create([
+            'password' => bcrypt('password123'),
+        ]);
+
+        // Act
+        $response = $this->post(route('login'), [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+
+    /** @test */
+    public function 存在しないメールアドレスではログインできない(): void
+    {
+        // Act
+        $response = $this->post(route('login'), [
+            'email' => 'nonexistent@example.com',
+            'password' => 'password123',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+
+    /** @test */
+    public function メールアドレスが空だとバリデーションエラーになる(): void
+    {
+        // Act
+        $response = $this->post(route('login'), [
+            'email' => '',
+            'password' => 'password123',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('email');
+    }
+
+    /** @test */
+    public function パスワードが空だとバリデーションエラーになる(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act
+        $response = $this->post(route('login'), [
+            'email' => $user->email,
+            'password' => '',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('password');
+    }
+
+    /** @test */
+    public function ログアウトできる(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act
+        $response = $this->actingAs($user)->post(route('logout'));
+
+        // Assert
+        $response->assertRedirect('/');
+        $this->assertGuest();
+    }
+
+    /** @test */
+    public function 認証済みユーザーはログインページにアクセスするとリダイレクトされる(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // Act
+        $response = $this->actingAs($user)->get(route('login'));
+
+        // Assert
+        $response->assertRedirect(route('tasks.index'));
+    }
+}

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class RegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A basic feature test example.
+     */
+    public function test_example(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+
+    public function 登録画面を表示できる(): void
+    {
+        $response = $this->get(route('register'));
+        $response->assetsStatus(200);
+    }
+
+    public function 新規登録ユーザーを登録できる() : void
+    {
+        $response = $this->post(route('register'),[
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertRedirect(route('tasks.index'));
+        $this->assertDatabaseJas('users', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+        ]);
+        $this->assertAuthentication();
+    }
+
+    public function 名前が空だとバリデーションエラーになる(): void
+    {
+        $response = $this->post(route('register'), [
+            'name' => '',
+            'email' => 'test@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+        $response->assertSessionHasErrors('name');
+    }
+
+    public function メールアドレスが空だとバリデーションエラーになる(): void
+    {
+        $response = $this->post(route('register'), [
+            'name' => 'テストユーザー',
+            'email' => '',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+        $response->assertSessionHasErrors('email');
+    }
+
+    public function 無効なメール形式だとバリデーションエラーになる(): void
+    {
+        $response = $this->post(route('register'), [
+            'name' => 'テストユーザー',
+            'email' => 'invalid-email',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+        $response->assertSessionHasErrors('email');
+    }
+
+    public function 既に登録済のメールアドレスだとバリデーションエラーになる(): void
+    {
+        User::factory()->create(['email' => 'existing@example.com']);
+        $response = $this->post(route('register'), [
+            'name' => 'テストユーザー',
+            'email' => 'existing@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+        $response->assertSessionHasErrors('email');
+    }
+
+    public function パスワードが8文字未満だとバリデーションエラーになる(): void
+    {
+        $response = $this->post(route('register'), [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => 'short',
+            'password_confirmation' => 'short',
+        ]);
+        $response->assertSessionHasErrors('password');
+    }
+
+    public function パスワード確認が一致しないとバリデーションエラーになる(): void
+    {
+        $response = $this->post(route('register'), [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password456',
+        ]);
+        $response->assertSessionHasErrors('password');
+    }
+
+}

--- a/tests/Feature/UnauthenticatedRedirectTest.php
+++ b/tests/Feature/UnauthenticatedRedirectTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UnauthenticatedRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function 未認証ユーザーはタスク一覧にアクセスするとログインページにリダイレクトされる(): void
+    {
+        $response = $this->get(route('tasks.index'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    /** @test */
+    public function 未認証ユーザーはタスク作成画面にアクセスするとログインページにリダイレクトされる(): void
+    {
+        $response = $this->get(route('tasks.create'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    /** @test */
+    public function 未認証ユーザーはカテゴリー一覧にアクセスするとログインページにリダイレクトされる(): void
+    {
+        $response = $this->get(route('categories.index'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    /** @test */
+    public function 未認証ユーザーはカテゴリー作成画面にアクセスするとログインページにリダイレクトされる(): void
+    {
+        $response = $this->get(route('categories.create'));
+
+        $response->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
## 概要
認証機能（ログイン・登録・リダイレクト）に対するテストを実装しました。

## 変更内容
- AuthenticationTestの作成（ログイン機能）
- RegistrationTestの作成（ユーザー登録機能）
- UnauthenticatedRedirectTestの作成（未認証リダイレクト）

## テスト項目
- [ ] ログインテスト（8テスト：正常系4 + 異常系4）
- [ ] 登録テスト（8テスト：正常系2 + 異常系5 + 境界値1）
- [ ] 未認証リダイレクトテスト（4テスト：異常系4）

※ ログインテストは境界値を省略（登録時に検証済みのため）

## 対応Issue
close #9